### PR TITLE
update: Node.js 24.12.0, pnpm 10.25.0, @types/node 24.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "typescript": "^5.9.3",
     "vite": "^6.3.5"
   },
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@10.25.0",
   "volta": {
-    "node": "22.13.1",
-    "pnpm": "9.15.4"
+    "node": "24.12.0",
+    "pnpm": "10.25.0"
   },
   "dependencies": {
     "zod": "^4.1.13"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
-    "@types/node": "^22.15.17",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "postcss": "^8.5.3",

--- a/packages/db-api/package.json
+++ b/packages/db-api/package.json
@@ -14,6 +14,6 @@
     "fast-xml-parser": "^5.2.3"
   },
   "devDependencies": {
-    "@types/node": "^22.15.17"
+    "@types/node": "^24.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.17)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.7.1)
+        version: 6.3.5(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.7.1)
 
   packages/app:
     dependencies:
@@ -68,8 +68,8 @@ importers:
         specifier: ^4.1.18
         version: 4.1.18
       '@types/node':
-        specifier: ^22.15.17
-        version: 22.15.17
+        specifier: ^24.1.0
+        version: 24.10.4
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -97,8 +97,8 @@ importers:
         version: 5.2.3
     devDependencies:
       '@types/node':
-        specifier: ^22.15.17
-        version: 22.15.17
+        specifier: ^24.1.0
+        version: 24.10.4
 
 packages:
 
@@ -714,8 +714,8 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
-  '@types/node@22.15.17':
-    resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
+  '@types/node@24.10.4':
+    resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1073,8 +1073,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici@6.21.1:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
@@ -1540,9 +1540,9 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
-  '@types/node@22.15.17':
+  '@types/node@24.10.4':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.16.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
@@ -1931,7 +1931,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.16.0: {}
 
   undici@6.21.1: {}
 
@@ -1939,7 +1939,7 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  vite@6.3.5(@types/node@22.15.17)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.7.1):
+  vite@6.3.5(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -1948,7 +1948,7 @@ snapshots:
       rollup: 4.40.2
       tinyglobby: 0.2.13
     optionalDependencies:
-      '@types/node': 22.15.17
+      '@types/node': 24.10.4
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Node.js: 22.13.1 → 24.12.0
- pnpm: 9.15.4 → 10.25.0
- @types/node: 22.15.17 → 24.1.0

## Test plan
- [ ] ビルドが正常に完了することを確認
- [ ] 既存の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)